### PR TITLE
Issue #6 recude webpage filesizes by referencing a list of subdirectories

### DIFF
--- a/lib/ImageMetaTag/webpage.py
+++ b/lib/ImageMetaTag/webpage.py
@@ -26,7 +26,7 @@ TODO: set up the dojo scripts/resources in a section for template type files
 .. moduleauthor:: Malcolm Brooks https://github.com/malcolmbrooks
 '''
 
-import os
+import os, pdb
 from ImageMetaTag import ImageDict
 
 def write_full_page(img_dict, filepath, title, page_filename=None, tab_s_name=None,
@@ -261,7 +261,10 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
     # their final details, and the id values of the key lists that refer to them:
 
 
-    # write out the file names:
+    # write out the file names in two stages, first the subdirectories, then use those
+    # in the filenames..
+    file_obj.write('var sd = %s;\n' % img_dict.subdirs)
+        
     file_obj.write('var file_list = [\n')
     for (item, ind_of_item) in enumerate(key_ind):
         tmp_dict = img_dict.dict
@@ -273,16 +276,20 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
             raise ValueError, 'Bottom level of plot dictionary contains more dictionaries!'
         elif isinstance(tmp_dict, str):
             # a string - this content is the plot it's referring to:
-            if item < len(key_ind)-1:
-                file_obj.write('  "%s",\n' % (tmp_dict))
+            img_path_split = os.path.split(tmp_dict)
+            sd_ind = img_dict.subdirs.index(img_path_split[0])
+            if item < len(key_ind) - 1:
+                file_obj.write('  sd[%s] + "/%s",\n' % (sd_ind, img_path_split[1]))
             else:
-                file_obj.write('  "%s"\n' % (tmp_dict))
+                file_obj.write('  sd[%s] + "/%s"' % (sd_ind, img_path_split[1]))
         elif isinstance(tmp_dict, list):
             # a list of plots:
             if len(tmp_dict) > 0:
                 out_list_str = '  ['
                 for list_content in tmp_dict:
-                    out_list_str += '"%s", ' % list_content
+                    img_path_split = os.path.split(list_content)
+                    sd_ind = img_dict.subdirs.index(img_path_split[0])
+                    out_list_str += 'sd[%s] + "%s", ' % (sd_ind, img_path_split[1])
                 out_list_str = out_list_str[0:-2] + ']'
             else:
                 # write out an empty list... not sure how the javascript would interpret that!

--- a/lib/ImageMetaTag/webpage.py
+++ b/lib/ImageMetaTag/webpage.py
@@ -232,22 +232,22 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
                 # this key list only has one thing in it!
                 if level < dict_depth - 1:
                     # and it's not the last key;
-                    file_obj.write('{id: %s, list: [{id: 0, label: "%s"}]},\n' % (level, key_name))
+                    file_obj.write('{id:%s,list:[{id:0,label:"%s"}]},\n' % (level, key_name))
                 else:
                     # it's also the last key (so not comma!)
-                    file_obj.write('{id: %s, list: [{id: 0, label: "%s"}]}\n' % (level, key_name))
+                    file_obj.write('{id:%s,list:[{id:0,label:"%s"}]}\n' % (level, key_name))
             elif key_id == 0:
                 # the start of a key list:
-                file_obj.write('{id: %s, list: [{id: 0, label: "%s"},\n' % (level, key_name))
+                file_obj.write('{id:%s,list:[{id:0,label:"%s"},\n' % (level, key_name))
             elif key_id < len(keys[level]) - 1:
                 # not the last item for this key list:
-                file_obj.write('{id: %s, label: "%s"},\n' %(key_id, key_name))
+                file_obj.write('{id:%s,label:"%s"},\n' %(key_id, key_name))
             elif level < dict_depth - 1:
                 # the last item for this key list, but it's not the last one:
-                file_obj.write('{id: %s, label: "%s"}]},\n' %(key_id, key_name))
+                file_obj.write('{id:%s,label:"%s"}]},\n' %(key_id, key_name))
             else:
                 # the last item of the last key list (so no comma!)
-                file_obj.write('{id: %s, label: "%s"}]}\n' %(key_id, key_name))
+                file_obj.write('{id:%s,label:"%s"}]}\n' %(key_id, key_name))
 
     # and close the plot dictionary var:
     file_obj.write('];\n')
@@ -279,9 +279,9 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
             img_path_split = os.path.split(tmp_dict)
             sd_ind = img_dict.subdirs.index(img_path_split[0])
             if item < len(key_ind) - 1:
-                file_obj.write('sd[%s] + "/%s",\n' % (sd_ind, img_path_split[1]))
+                file_obj.write('sd[%s]+"/%s",\n' % (sd_ind, img_path_split[1]))
             else:
-                file_obj.write('sd[%s] + "/%s"' % (sd_ind, img_path_split[1]))
+                file_obj.write('sd[%s]+"/%s"' % (sd_ind, img_path_split[1]))
         elif isinstance(tmp_dict, list):
             # a list of plots:
             if len(tmp_dict) > 0:
@@ -289,7 +289,7 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
                 for list_content in tmp_dict:
                     img_path_split = os.path.split(list_content)
                     sd_ind = img_dict.subdirs.index(img_path_split[0])
-                    out_list_str += 'sd[%s] + "%s", ' % (sd_ind, img_path_split[1])
+                    out_list_str += 'sd[%s]+"%s", ' % (sd_ind, img_path_split[1])
                 out_list_str = out_list_str[0:-2] + ']'
             else:
                 # write out an empty list... not sure how the javascript would interpret that!
@@ -320,20 +320,17 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
         elif isinstance(tmp_dict, (str, list)):
             # a string, or list of strings - this content is the plot it's referring to:
             if item < len(key_ind)-1:
-                file_obj.write('  %s,\n' % (ind_of_item))
+                file_obj.write('%s,\n' % (str(ind_of_item).replace(' ', '')))
             else:
-                file_obj.write('  %s\n' % (ind_of_item))
+                file_obj.write('%s\n' % (str(ind_of_item).replace(' ', '')))
         else:
             msg = 'Wrong type of thing (%s) at bottom of the plot dictionary:\n  %s' \
                             % (type(tmp_dict), tmp_dict)
             raise ValueError(msg)
-    file_obj.write(']\n')
+    file_obj.write('];\n')
 
     # close the javascript section:
-    file_obj.write('''
-</script>
-
-''')
+    file_obj.write('</script>')
 
 def write_js_setup(img_dict, file_obj=None, pagename=None, tab_s_name=None,
                    initial_selectors=None,

--- a/lib/ImageMetaTag/webpage.py
+++ b/lib/ImageMetaTag/webpage.py
@@ -232,22 +232,22 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
                 # this key list only has one thing in it!
                 if level < dict_depth - 1:
                     # and it's not the last key;
-                    file_obj.write('  {id: %s, list: [{id: 0, label: "%s"}]},\n' % (level, key_name))
+                    file_obj.write('{id: %s, list: [{id: 0, label: "%s"}]},\n' % (level, key_name))
                 else:
                     # it's also the last key (so not comma!)
-                    file_obj.write('  {id: %s, list: [{id: 0, label: "%s"}]}\n' % (level, key_name))
+                    file_obj.write('{id: %s, list: [{id: 0, label: "%s"}]}\n' % (level, key_name))
             elif key_id == 0:
                 # the start of a key list:
-                file_obj.write('  {id: %s, list: [{id: 0, label: "%s"},\n' % (level, key_name))
+                file_obj.write('{id: %s, list: [{id: 0, label: "%s"},\n' % (level, key_name))
             elif key_id < len(keys[level]) - 1:
                 # not the last item for this key list:
-                file_obj.write('        {id: %s, label: "%s"},\n' %(key_id, key_name))
+                file_obj.write('{id: %s, label: "%s"},\n' %(key_id, key_name))
             elif level < dict_depth - 1:
                 # the last item for this key list, but it's not the last one:
-                file_obj.write('        {id: %s, label: "%s"}]},\n' %(key_id, key_name))
+                file_obj.write('{id: %s, label: "%s"}]},\n' %(key_id, key_name))
             else:
                 # the last item of the last key list (so no comma!)
-                file_obj.write('        {id: %s, label: "%s"}]}\n' %(key_id, key_name))
+                file_obj.write('{id: %s, label: "%s"}]}\n' %(key_id, key_name))
 
     # and close the plot dictionary var:
     file_obj.write('];\n')
@@ -279,13 +279,13 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
             img_path_split = os.path.split(tmp_dict)
             sd_ind = img_dict.subdirs.index(img_path_split[0])
             if item < len(key_ind) - 1:
-                file_obj.write('  sd[%s] + "/%s",\n' % (sd_ind, img_path_split[1]))
+                file_obj.write('sd[%s] + "/%s",\n' % (sd_ind, img_path_split[1]))
             else:
-                file_obj.write('  sd[%s] + "/%s"' % (sd_ind, img_path_split[1]))
+                file_obj.write('sd[%s] + "/%s"' % (sd_ind, img_path_split[1]))
         elif isinstance(tmp_dict, list):
             # a list of plots:
             if len(tmp_dict) > 0:
-                out_list_str = '  ['
+                out_list_str = '['
                 for list_content in tmp_dict:
                     img_path_split = os.path.split(list_content)
                     sd_ind = img_dict.subdirs.index(img_path_split[0])
@@ -293,7 +293,7 @@ def write_js(img_dict, file_obj=None, selector_prefix=None, list_prefix=None, fi
                 out_list_str = out_list_str[0:-2] + ']'
             else:
                 # write out an empty list... not sure how the javascript would interpret that!
-                out_list_str = '  []'
+                out_list_str = '[]'
                 msg = 'Webpage not prepared to handle empty lists - not sure what they mean!'
                 raise NotImplementedError(msg)
             if item < len(key_ind)-1:

--- a/test.py
+++ b/test.py
@@ -110,7 +110,11 @@ def plot_random_data(random_data, i_rand, plot_col, col_name, trims, borders,
     else:
         plt.title('Sum of two random integers between 1 and 6\n')
 
-    outfile = '%s/rolls_%s_%s.%s' % (img_savedir, n_rolls, plot_col, img_format)
+
+    # plot individual rolls:
+    rolls_savedir = '%s/rolls' % img_savedir
+    mkdir_p(rolls_savedir)
+    outfile = '%s/%s_%s.%s' % (rolls_savedir, n_rolls, plot_col, img_format)
     plt.savefig(outfile)
 
     # save the figure, using different image-meta-tag options
@@ -122,8 +126,8 @@ def plot_random_data(random_data, i_rand, plot_col, col_name, trims, borders,
             these_borders = [0]
         for border in these_borders:
             for compression in compression_levels:
-                outfile = '%s/rolls_imt_%s_%s_compression_%s' \
-                        % (img_savedir, n_rolls, plot_col, compression)
+                outfile = '%s/imt_%s_%s_compression_%s' \
+                        % (rolls_savedir, n_rolls, plot_col, compression)
                 if trim:
                     outfile += '_trim_b%s' % border
                     trim_str = 'Image trimmed'
@@ -160,8 +164,10 @@ def plot_random_data(random_data, i_rand, plot_col, col_name, trims, borders,
 
     plt.close()
 
-
-    outfile = '%s/dist_%s_%s.%s' % (img_savedir, n_rolls, plot_col, img_format)
+    # now plot distributions:
+    dist_savedir = '%s/dists' % img_savedir
+    mkdir_p(dist_savedir)
+    outfile = '%s/%s_%s.%s' % (dist_savedir, n_rolls, plot_col, img_format)
     _count, _bins, _ignored = plt.hist(random_data[i_rand],
                                        [x + 0.5 for x in range(13)],
                                        color=plot_col, normed=True)
@@ -176,8 +182,8 @@ def plot_random_data(random_data, i_rand, plot_col, col_name, trims, borders,
             these_borders = [0]
         for border in these_borders:
             for compression in compression_levels:
-                outfile = '%s/dist_imt_%s_%s_compression_%s' \
-                        % (img_savedir, n_rolls, plot_col, compression)
+                outfile = '%s/imt_%s_%s_compression_%s' \
+                        % (dist_savedir, n_rolls, plot_col, compression)
                 if trim:
                     outfile += '_trim_b%s' % border
                     trim_str = 'Image trimmed'
@@ -388,7 +394,7 @@ def __main__():
         raise ValueError('images_and_tags differ between database and plotting/pickle versions')
     # now make the next page:
     n_proc = 4
-    skip_key_relist = False # default setting
+    skip_key_relist = True
     extra_opts = (tagorder, skip_key_relist, selector_animated, animation_direction)
     subdict_gen = imt.dict_split(db_images_and_tags, n_split=n_proc, extra_opts=extra_opts)
     if n_proc == 1:
@@ -404,10 +410,18 @@ def __main__():
         proc_pool.close()
         proc_pool.join()
 
+
+
     # now stitch the parallel image dict back together:
     img_dict_para = pool_out[0]
     for i_dict in range(1, len(pool_out)):
         img_dict_para.append(pool_out[i_dict])
+        
+    if skip_key_relist:
+        # if we skipped relisting the keys (as it's faster to do that)
+        # then make sure we list them at the end:
+        img_dict_para.list_keys_by_depth()
+
 
     # sort the keys:
     img_dict.sort_keys(sort_methods)
@@ -742,7 +756,7 @@ def __main__():
                                     for i_8 in xrange(8):
                                         for i_9 in xrange(9):
                                             # we don't want to actually make an image!
-                                            img_name = 'no_image_%s_%s_%s_%s_%s_%s_%s_%s_%s.png ' \
+                                            img_name = '%s/%s/%s/%s/%s/%s_%s_%s_%s_no_image.png ' \
                                                     % (i_1, i_2, i_3, i_4, i_5, i_6, i_7, i_8, i_9)
                                             img_info = {'l1': 'Lev 1: %s' % i_1,
                                                         'l2': 'Lev 2: %s' % i_2,
@@ -821,7 +835,7 @@ def __main__():
         print_simple_timer(date_start_big, datetime.now(), 'Large parallel dict processing')
         # and now make we big dict webpage (and time it too)
         date_start_web = datetime.now()
-        out_page_big = '%s/biggus_pageus.html' % img_savedir
+        out_page_big = '%s/biggus_pageus.html' % webdir
         imt.webpage.write_full_page(biggus_dictus_imigus, out_page_big,
                                     'Test ImageDict webpage', verbose=True, internal=False)
         print_simple_timer(date_start_web, datetime.now(), 'Large parallel dict webpage')


### PR DESCRIPTION
As part of issue #6 the large arrays of file locations have been reduced in size by referencing a list of subdirectories (and removing whitespace that gave nice formatting when reading html, but did nothing).