### PR TITLE
Deleted symlink added by mistake

### DIFF
--- a/docs/build/html/ImageMetaTagDocs
+++ b/docs/build/html/ImageMetaTagDocs
@@ -1,1 +1,0 @@
-/home/h01/freb/public_html/ImageMetaTagDocs


### PR DESCRIPTION
Symlink was accidentally created when setting up internal version of documentation and is not neded