### PR TITLE
Move to using PIL.Image rather than the old Image library

### DIFF
--- a/lib/ImageMetaTag/img_dict.py
+++ b/lib/ImageMetaTag/img_dict.py
@@ -4,7 +4,8 @@ Submodule containing an ImageDict class, and functions for preparing them.
 @author: Malcolm.E.Brooks@metoffice.gov.uk
 '''
 # required imports
-import Image, os, re, collections, inspect
+import os, re, collections, inspect
+from PIL import Image
 # useful for debugging
 import pdb
 

--- a/lib/ImageMetaTag/savefig.py
+++ b/lib/ImageMetaTag/savefig.py
@@ -12,8 +12,7 @@ from datetime import datetime
 from ImageMetaTag import db, META_IMG_FORMATS, DEFAULT_DB_TIMEOUT, DEFAULT_DB_ATTEMPTS
 
 # image manipulations:
-import Image, ImageChops
-from PIL import PngImagePlugin
+from PIL import Image, ImageChops, PngImagePlugin
 import numpy as np
 
 THUMB_DEFAULT_IMG_SIZE = 150, 150
@@ -413,12 +412,12 @@ def _img_premult_resize(img_obj, size=None):
         size = (40, 40)
 
     img_obj = img_obj.convert('RGBA')
-    premult = np.fromstring(img_obj.tostring(), dtype=np.uint8)
+    premult = np.fromstring(img_obj.tobytes(), dtype=np.uint8)
     alpha_layer = premult[3::4] / 255.0
     premult[0::4] = premult[0::4] * alpha_layer
     premult[1::4] = premult[1::4] * alpha_layer
     premult[2::4] = premult[2::4] * alpha_layer
-    new_img_obj = Image.fromstring("RGBA", img_obj.size, premult.tostring())
+    new_img_obj = Image.frombytes("RGBA", img_obj.size, premult.tobytes())
 
     #new_img_obj = new_img_obj.filter(ImageFilter.SMOOTH)
     res_img_obj = new_img_obj.resize(size, Image.ANTIALIAS)

--- a/lib/ImageMetaTag/webpage.py
+++ b/lib/ImageMetaTag/webpage.py
@@ -528,9 +528,8 @@ def write_js_placeholders(file_obj=None, dict_depth=None, selector_prefix=None,
 
         # now add somewhere for the image to go:
         file_obj.write('''   <div id="the_image">Please wait while the page is loading</div>
-   <br>
    <div id="the_url">....</div>''')
-
+        # and finish off the placeholders:
         file_obj.write('''
    </font>
   </td>


### PR DESCRIPTION
Simple to change, as we were already importing from PIL for ImageChops this reduced dependencies rather than adds to them.