### PR TITLE
Img save to mem

### DIFF
--- a/ImageMetaTag/__init__.py
+++ b/ImageMetaTag/__init__.py
@@ -25,6 +25,8 @@ __documentation__ = 'http://scitools-incubator.github.io/image-meta-tag/build/ht
 
 # list fo file formats which are valid for saving metadata to:
 META_IMG_FORMATS = ['png']
+# and which can do image post-processing
+POSTPROC_IMG_FORMATS = ['png']
 
 # default timeout and retries for database access:
 DEFAULT_DB_TIMEOUT = 6

--- a/ImageMetaTag/savefig.py
+++ b/ImageMetaTag/savefig.py
@@ -103,8 +103,6 @@ def savefig(filename, img_format=None, img_converter=0, do_trim=False, trim_bord
         plt.savefig(savefig_file)
     if not keep_open:
         plt.close()
-    if not keep_open:
-        plt.close()
     if buf:
         # need to go to the start of the buffer, if that's where it went:
         buf.seek(0)


### PR DESCRIPTION
If any image post-processing is required, the savefig command will now save to an IO buffer in memory, rather than to an initial file (which would then need to be read in, and usually overwritten).

Testing shows this change does not noticeably speed up writing out the images, but it should reduce the disk load on any systems doing a lot of plotting.