### PR TITLE
Fix to installing outside conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pydevproject
 *.pyc
 *~
+.settings

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup_args = dict(
     test_suite = 'python test.py',
     classifiers = ['Programming Language :: Python :: 2.7',
                   ],
-    package_data = {'ImageMetaTag': ['javascript', 'javascript/*']},
+    package_data = {'ImageMetaTag': ['javascript/*']},
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Conda needs the javascript to be in a package_dir, but this broke setup.py for non-conda isntall. This hopefully fixes that, while conda hopefully still works.

Merging to master, and will test non-conda installs again. If it works, then hopefully conda won't be broken on the next release!