### PR TITLE
Forecast lead time string changed to deal with negative values

### DIFF
--- a/ImageMetaTag/img_dict.py
+++ b/ImageMetaTag/img_dict.py
@@ -495,7 +495,7 @@ class ImageDict(object):
                     # get a list of tuples, containing the string, and the value
                     # of the T+ from a pattern match regex:
                     try:
-                        labels_and_values = [(x, re.match('[tT][+]{,}([0-9.]{1,})|None', x).group(1)) for x in self.keys[i_key]]
+                        labels_and_values = [(x, re.match('[tT]([-+0-9.]{1,})|None', x).group(1)) for x in self.keys[i_key]]
                         if method == 'T+':
                             # map the None to a string, so it goes to then end of a sort
                             labels_and_values = [(x, float(y)) if not y is None else (x, 'None') for x, y in labels_and_values]


### PR DESCRIPTION
Negative values of forecast lead time now sorted for correcly in ImageDict.sort_keys().

This is an example where fixing issue #95 would allow this to be fixed in user/application specific code rather than in the library.

